### PR TITLE
Add a new components to CDI.

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaBuildTimeConfig.java
@@ -59,7 +59,7 @@ public interface DomaBuildTimeConfig {
     @WithDefault("none")
     SqlLogType exceptionSqlLogType();
 
-    SqlBuilderBuildTimeConfig sqlBuilderSettings();
+    SqlBuilderSettingsBuildTimeConfig sqlBuilderSettings();
 
     /**
      * An exception will be thrown if duplicate columns exist.
@@ -128,7 +128,7 @@ public interface DomaBuildTimeConfig {
     }
 
     @ConfigGroup
-    public interface SqlBuilderBuildTimeConfig {
+    public interface SqlBuilderSettingsBuildTimeConfig {
         /**
          * Whether to remove blank lines from SQL.
          * If {@link org.seasar.doma.jdbc.SqlBuilderSettings} is registered in CDI, this property will be ignored.

--- a/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaBuildTimeConfig.java
@@ -59,7 +59,7 @@ public interface DomaBuildTimeConfig {
     @WithDefault("none")
     SqlLogType exceptionSqlLogType();
 
-    public SqlBuilderBuildTimeConfig sqlBuilderSettings;
+    SqlBuilderBuildTimeConfig sqlBuilderSettings();
 
     /**
      * An exception will be thrown if duplicate columns exist.
@@ -67,10 +67,9 @@ public interface DomaBuildTimeConfig {
      *
      * @see Config#getDuplicateColumnHandler()
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean throwExceptionIfDuplicateColumn;
+    @WithDefault("false")
+    boolean throwExceptionIfDuplicateColumn();
 
-    @SuppressWarnings("CanBeFinal")
     @ConfigGroup
     public interface DataSourceBuildTimeConfig {
         /**
@@ -126,5 +125,26 @@ public interface DomaBuildTimeConfig {
          */
         @ConfigDocDefault("import.sql in DEV, TEST ; no-file otherwise")
         Optional<String> sqlLoadScript();
+    }
+
+    @ConfigGroup
+    public interface SqlBuilderBuildTimeConfig {
+        /**
+         * Whether to remove blank lines from SQL.
+         * If {@link org.seasar.doma.jdbc.SqlBuilderSettings} is registered in CDI, this property will be ignored.
+         *
+         * @see SqlBuilderSettings#shouldRemoveBlankLines()
+         */
+        @WithDefault("false")
+        boolean shouldRemoveBlankLines();
+
+        /**
+         * Whether to enable IN list padding.
+         * If {@link org.seasar.doma.jdbc.SqlBuilderSettings} is registered in CDI, this property will be ignored.
+         *
+         * @see SqlBuilderSettings#shouldRequireInListPadding()
+         */
+        @WithDefault("false")
+        boolean shouldRequireInListPadding();
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaBuildTimeConfig.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.SqlBuilderSettings;
 import org.seasar.doma.jdbc.SqlLogType;
 
 import io.quarkiverse.doma.runtime.DomaSettings;
@@ -52,6 +53,17 @@ public class DomaBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "none")
     public SqlLogType exceptionSqlLogType;
+
+    public SqlBuilderBuildTimeConfig sqlBuilderSettings;
+
+    /**
+     * An exception will be thrown if duplicate columns exist.
+     * If {@link org.seasar.doma.jdbc.DuplicateColumnHandler} is registered in CDI, this property will be ignored.
+     *
+     * @see Config#getDuplicateColumnHandler()
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean throwExceptionIfDuplicateColumn;
 
     @SuppressWarnings("CanBeFinal")
     @ConfigGroup
@@ -131,6 +143,37 @@ public class DomaBuildTimeConfig {
         }
     }
 
+    @SuppressWarnings("CanBeFinal")
+    @ConfigGroup
+    public static class SqlBuilderBuildTimeConfig {
+        /**
+         * Whether to remove blank lines from SQL.
+         * If {@link org.seasar.doma.jdbc.SqlBuilderSettings} is registered in CDI, this property will be ignored.
+         *
+         * @see SqlBuilderSettings#shouldRemoveBlankLines()
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean shouldRemoveBlankLines;
+        /**
+         * Whether to enable IN list padding.
+         * If {@link org.seasar.doma.jdbc.SqlBuilderSettings} is registered in CDI, this property will be ignored.
+         *
+         * @see SqlBuilderSettings#shouldRequireInListPadding()
+         */
+        @ConfigItem(defaultValue = "false")
+        public boolean shouldRequireInListPadding;
+
+        @Override
+        public String toString() {
+            return "SqlBuilderBuildTimeConfig{"
+                    + "shouldRemoveBlankLines="
+                    + shouldRemoveBlankLines
+                    + ", shouldRequireInListPadding="
+                    + shouldRequireInListPadding
+                    + '}';
+        }
+    }
+
     @Override
     public String toString() {
         return "DomaBuildTimeConfig{"
@@ -144,6 +187,10 @@ public class DomaBuildTimeConfig {
                 + naming
                 + ", exceptionSqlLogType="
                 + exceptionSqlLogType
+                + ", sqlBuilderSettings="
+                + sqlBuilderSettings
+                + ", throwExceptionIfDuplicateColumn="
+                + throwExceptionIfDuplicateColumn
                 + '}';
     }
 }

--- a/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaSettingsFactory.java
+++ b/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaSettingsFactory.java
@@ -46,10 +46,10 @@ public class DomaSettingsFactory {
             throw new IllegalStateException("The quarkus.datasource is empty. Specify it.");
         }
         DomaSettings.SqlBuilderSettings sqlBuilderSettings = new DomaSettings.SqlBuilderSettings();
-        sqlBuilderSettings.shouldRemoveBlankLines = buildTimeConfig.sqlBuilderSettings.shouldRemoveBlankLines;
-        sqlBuilderSettings.shouldRequireInListPadding = buildTimeConfig.sqlBuilderSettings.shouldRequireInListPadding;
+        sqlBuilderSettings.shouldRemoveBlankLines = buildTimeConfig.sqlBuilderSettings().shouldRemoveBlankLines();
+        sqlBuilderSettings.shouldRequireInListPadding = buildTimeConfig.sqlBuilderSettings().shouldRequireInListPadding();
         settings.sqlBuilderSettings = sqlBuilderSettings;
-        settings.throwExceptionIfDuplicateColumn = buildTimeConfig.throwExceptionIfDuplicateColumn;
+        settings.throwExceptionIfDuplicateColumn = buildTimeConfig.throwExceptionIfDuplicateColumn();
         logger.debugf("settings: %s", settings);
         return settings;
     }

--- a/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaSettingsFactory.java
+++ b/deployment/src/main/java/io/quarkiverse/doma/deployment/DomaSettingsFactory.java
@@ -49,6 +49,11 @@ public class DomaSettingsFactory {
         if (dataSources.isEmpty()) {
             throw new IllegalStateException("The quarkus.datasource is empty. Specify it.");
         }
+        DomaSettings.SqlBuilderSettings sqlBuilderSettings = new DomaSettings.SqlBuilderSettings();
+        sqlBuilderSettings.shouldRemoveBlankLines = buildTimeConfig.sqlBuilderSettings.shouldRemoveBlankLines;
+        sqlBuilderSettings.shouldRequireInListPadding = buildTimeConfig.sqlBuilderSettings.shouldRequireInListPadding;
+        settings.sqlBuilderSettings = sqlBuilderSettings;
+        settings.throwExceptionIfDuplicateColumn = buildTimeConfig.throwExceptionIfDuplicateColumn;
         logger.debugf("settings: %s", settings);
         return settings;
     }

--- a/deployment/src/test/java/io/quarkiverse/doma/deployment/InjectConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/doma/deployment/InjectConfigTest.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.doma.deployment;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
 import jakarta.transaction.Status;

--- a/deployment/src/test/java/io/quarkiverse/doma/deployment/InjectConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/doma/deployment/InjectConfigTest.java
@@ -1,8 +1,6 @@
 package io.quarkiverse.doma.deployment;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.inject.Inject;
 import jakarta.transaction.Status;
@@ -15,6 +13,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.ConfigSupport;
 import org.seasar.doma.jdbc.RequiresNewController;
 import org.seasar.doma.jdbc.criteria.Entityql;
 import org.seasar.doma.jdbc.criteria.NativeSql;
@@ -80,6 +79,9 @@ public class InjectConfigTest {
         assertNotNull(nativeSql);
         assertNotNull(queryDsl);
         assertNotNull(scriptExecutor);
+        assertFalse(config.getSqlBuilderSettings().shouldRemoveBlankLines());
+        assertFalse(config.getSqlBuilderSettings().shouldRequireInListPadding());
+        assertEquals(config.getDuplicateColumnHandler().getClass(), ConfigSupport.defaultDuplicateColumnHandler.getClass());
     }
 
     @Test

--- a/deployment/src/test/java/io/quarkiverse/doma/deployment/InjectConfigTest.java
+++ b/deployment/src/test/java/io/quarkiverse/doma/deployment/InjectConfigTest.java
@@ -1,8 +1,8 @@
 package io.quarkiverse.doma.deployment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;

--- a/deployment/src/test/java/io/quarkiverse/doma/deployment/OverrideBeanTest.java
+++ b/deployment/src/test/java/io/quarkiverse/doma/deployment/OverrideBeanTest.java
@@ -15,9 +15,14 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.seasar.doma.jdbc.CommentContext;
 import org.seasar.doma.jdbc.Commenter;
 import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.DuplicateColumnHandler;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.NoCacheSqlFileRepository;
+import org.seasar.doma.jdbc.Sql;
+import org.seasar.doma.jdbc.SqlBuilderSettings;
 import org.seasar.doma.jdbc.SqlFileRepository;
+import org.seasar.doma.jdbc.statistic.Statistic;
+import org.seasar.doma.jdbc.statistic.StatisticManager;
 import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
 import org.seasar.doma.jdbc.tx.LocalTransactionManager;
 import org.seasar.doma.jdbc.tx.TransactionManager;
@@ -70,10 +75,52 @@ public class OverrideBeanTest {
         }
     }
 
+    @Singleton
+    @Unremovable
+    static class MyDuplicateColumnHandler implements DuplicateColumnHandler {
+    }
+
+    @Singleton
+    @Unremovable
+    static class MySqlBuilderSettings implements SqlBuilderSettings {
+    }
+
+    @Singleton
+    @Unremovable
+    static class MyStatisticManager implements StatisticManager {
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
+        @Override
+        public void setEnabled(boolean b) {
+
+        }
+
+        @Override
+        public Iterable<Statistic> getStatistics() {
+            return null;
+        }
+
+        @Override
+        public void recordSqlExecution(Sql<?> sql, long l, long l1) {
+
+        }
+
+        @Override
+        public void clear() {
+
+        }
+    }
+
     @Test
     void test() {
         assertTrue(config.getCommenter() instanceof MyCommenter);
         assertTrue(config.getSqlFileRepository() instanceof NoCacheSqlFileRepository);
         assertTrue(config.getTransactionManager() instanceof LocalTransactionManager);
+        assertTrue(config.getDuplicateColumnHandler() instanceof MyDuplicateColumnHandler);
+        assertTrue(config.getSqlBuilderSettings() instanceof MySqlBuilderSettings);
+        assertTrue(config.getStatisticManager() instanceof MyStatisticManager);
     }
 }

--- a/deployment/src/test/java/io/quarkiverse/doma/deployment/SqlBuilderSettingsTest.java
+++ b/deployment/src/test/java/io/quarkiverse/doma/deployment/SqlBuilderSettingsTest.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.doma.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.seasar.doma.jdbc.Config;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class SqlBuilderSettingsTest {
+    @SuppressWarnings("unused")
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .add(
+                                    new StringAsset(
+                                            "quarkus.datasource.db-kind=h2\n"
+                                                    + "quarkus.datasource.username=USERNAME-NAMED\n"
+                                                    + "quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:testing\n"
+                                                    + "quarkus.datasource.jdbc.driver=org.h2.Driver\n"
+                                                    + "quarkus.doma.sql-builder-settings.should-require-in-list-padding=true\n"
+                                                    + "quarkus.doma.sql-builder-settings.should-remove-blank-lines=true\n"),
+                                    "application.properties"));
+
+    @Inject
+    Config config;
+
+    @Test
+    void testSqlBuilderSettings() {
+        var sqlBuilderSettings = config.getSqlBuilderSettings();
+        assertTrue(sqlBuilderSettings.shouldRequireInListPadding());
+        assertTrue(sqlBuilderSettings.shouldRemoveBlankLines());
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/doma/deployment/ThrowingDuplicateColumnHandlerTest.java
+++ b/deployment/src/test/java/io/quarkiverse/doma/deployment/ThrowingDuplicateColumnHandlerTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.doma.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.ThrowingDuplicateColumnHandler;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ThrowingDuplicateColumnHandlerTest {
+    @SuppressWarnings("unused")
+    @RegisterExtension
+    static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .setArchiveProducer(
+                    () -> ShrinkWrap.create(JavaArchive.class)
+                            .add(
+                                    new StringAsset(
+                                            "quarkus.datasource.db-kind=h2\n"
+                                                    + "quarkus.datasource.username=USERNAME-NAMED\n"
+                                                    + "quarkus.datasource.jdbc.url=jdbc:h2:tcp://localhost/mem:testing\n"
+                                                    + "quarkus.datasource.jdbc.driver=org.h2.Driver\n"
+                                                    + "quarkus.doma.throw-exception-if-duplicate-column=true\n"),
+                                    "application.properties"));
+
+    @Inject
+    Config config;
+
+    @Test
+    void testThrowingDuplicateColumn() {
+        assertInstanceOf(ThrowingDuplicateColumnHandler.class, config.getDuplicateColumnHandler());
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DefaultSqlBuilderSettings.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DefaultSqlBuilderSettings.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.doma.runtime;
+
+import org.seasar.doma.jdbc.SqlBuilderSettings;
+
+final class DefaultSqlBuilderSettings implements SqlBuilderSettings {
+    private final boolean shouldRemoveBlankLines;
+    private final boolean shouldRequireInListPadding;
+
+    public DefaultSqlBuilderSettings(boolean shouldRemoveBlankLines, boolean shouldRequireInListPadding) {
+        this.shouldRemoveBlankLines = shouldRemoveBlankLines;
+        this.shouldRequireInListPadding = shouldRequireInListPadding;
+    }
+
+    @Override
+    public boolean shouldRemoveBlankLines() {
+        return shouldRemoveBlankLines;
+    }
+
+    @Override
+    public boolean shouldRequireInListPadding() {
+        return shouldRequireInListPadding;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaConfig.java
@@ -9,6 +9,7 @@ import org.seasar.doma.jdbc.ClassHelper;
 import org.seasar.doma.jdbc.CommandImplementors;
 import org.seasar.doma.jdbc.Commenter;
 import org.seasar.doma.jdbc.Config;
+import org.seasar.doma.jdbc.DuplicateColumnHandler;
 import org.seasar.doma.jdbc.EntityListenerProvider;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.MapKeyNaming;
@@ -16,10 +17,12 @@ import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.QueryImplementors;
 import org.seasar.doma.jdbc.RequiresNewController;
 import org.seasar.doma.jdbc.ScriptFileLoader;
+import org.seasar.doma.jdbc.SqlBuilderSettings;
 import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.SqlLogType;
 import org.seasar.doma.jdbc.UnknownColumnHandler;
 import org.seasar.doma.jdbc.dialect.Dialect;
+import org.seasar.doma.jdbc.statistic.StatisticManager;
 import org.seasar.doma.jdbc.tx.TransactionManager;
 
 @SuppressWarnings("unused")
@@ -42,6 +45,9 @@ public class DomaConfig implements Config {
     private final Commenter commenter;
     private final EntityListenerProvider entityListenerProvider;
     private final TransactionManager transactionManager;
+    private final DuplicateColumnHandler duplicateColumnHandler;
+    private final SqlBuilderSettings sqlBuilderSettings;
+    private final StatisticManager statisticManager;
     private final int batchSize;
     private final int fetchSize;
     private final int maxRows;
@@ -64,7 +70,8 @@ public class DomaConfig implements Config {
             MapKeyNaming mapKeyNaming,
             Commenter commenter,
             EntityListenerProvider entityListenerProvider,
-            TransactionManager transactionManager,
+            TransactionManager transactionManager, DuplicateColumnHandler duplicateColumnHandler,
+            SqlBuilderSettings sqlBuilderSettings, StatisticManager statisticManager,
             int batchSize,
             int fetchSize,
             int maxRows,
@@ -86,6 +93,9 @@ public class DomaConfig implements Config {
         this.commenter = Objects.requireNonNull(commenter);
         this.entityListenerProvider = Objects.requireNonNull(entityListenerProvider);
         this.transactionManager = Objects.requireNonNull(transactionManager);
+        this.duplicateColumnHandler = duplicateColumnHandler;
+        this.sqlBuilderSettings = sqlBuilderSettings;
+        this.statisticManager = statisticManager;
         this.batchSize = batchSize;
         this.fetchSize = fetchSize;
         this.maxRows = maxRows;
@@ -205,6 +215,21 @@ public class DomaConfig implements Config {
         return queryTimeout;
     }
 
+    @Override
+    public DuplicateColumnHandler getDuplicateColumnHandler() {
+        return duplicateColumnHandler;
+    }
+
+    @Override
+    public SqlBuilderSettings getSqlBuilderSettings() {
+        return sqlBuilderSettings;
+    }
+
+    @Override
+    public StatisticManager getStatisticManager() {
+        return statisticManager;
+    }
+
     @SuppressWarnings("unused")
     public static Builder builder() {
         return new Builder();
@@ -255,6 +280,9 @@ public class DomaConfig implements Config {
         builder.setCommenter(core.getCommenter());
         builder.setEntityListenerProvider(core.getEntityListenerProvider());
         builder.setTransactionManager(core.getTransactionManager());
+        builder.setDuplicateColumnHandler(core.getDuplicateColumnHandler());
+        builder.setSqlBuilderSettings(core.getSqlBuilderSettings());
+        builder.setStatisticManager(core.getStatisticManager());
         return builder;
     }
 
@@ -273,6 +301,9 @@ public class DomaConfig implements Config {
         private final Commenter commenter;
         private final EntityListenerProvider entityListenerProvider;
         private final TransactionManager transactionManager;
+        private final DuplicateColumnHandler duplicateColumnHandler;
+        private final SqlBuilderSettings sqlBuilderSettings;
+        private final StatisticManager statisticManager;
 
         public Core(
                 SqlFileRepository sqlFileRepository,
@@ -288,7 +319,10 @@ public class DomaConfig implements Config {
                 MapKeyNaming mapKeyNaming,
                 Commenter commenter,
                 EntityListenerProvider entityListenerProvider,
-                TransactionManager transactionManager) {
+                TransactionManager transactionManager,
+                DuplicateColumnHandler duplicateColumnHandler,
+                SqlBuilderSettings sqlBuilderSettings,
+                StatisticManager statisticManager) {
             this.sqlFileRepository = Objects.requireNonNull(sqlFileRepository);
             this.scriptFileLoader = Objects.requireNonNull(scriptFileLoader);
             this.jdbcLogger = Objects.requireNonNull(jdbcLogger);
@@ -303,6 +337,9 @@ public class DomaConfig implements Config {
             this.commenter = Objects.requireNonNull(commenter);
             this.entityListenerProvider = Objects.requireNonNull(entityListenerProvider);
             this.transactionManager = Objects.requireNonNull(transactionManager);
+            this.duplicateColumnHandler = duplicateColumnHandler;
+            this.sqlBuilderSettings = sqlBuilderSettings;
+            this.statisticManager = statisticManager;
         }
 
         public SqlFileRepository getSqlFileRepository() {
@@ -360,6 +397,18 @@ public class DomaConfig implements Config {
         public TransactionManager getTransactionManager() {
             return transactionManager;
         }
+
+        public DuplicateColumnHandler getDuplicateColumnHandler() {
+            return duplicateColumnHandler;
+        }
+
+        public SqlBuilderSettings getSqlBuilderSettings() {
+            return sqlBuilderSettings;
+        }
+
+        public StatisticManager getStatisticManager() {
+            return statisticManager;
+        }
     }
 
     @SuppressWarnings("UnusedReturnValue")
@@ -382,6 +431,9 @@ public class DomaConfig implements Config {
         private Commenter commenter;
         private EntityListenerProvider entityListenerProvider;
         private TransactionManager transactionManager;
+        private DuplicateColumnHandler duplicateColumnHandler;
+        private SqlBuilderSettings sqlBuilderSettings;
+        private StatisticManager statisticManager;
         private int batchSize;
         private int fetchSize;
         private int maxRows;
@@ -472,6 +524,18 @@ public class DomaConfig implements Config {
             return this;
         }
 
+        public void setDuplicateColumnHandler(DuplicateColumnHandler duplicateColumnHandler) {
+            this.duplicateColumnHandler = duplicateColumnHandler;
+        }
+
+        public void setSqlBuilderSettings(SqlBuilderSettings sqlBuilderSettings) {
+            this.sqlBuilderSettings = sqlBuilderSettings;
+        }
+
+        public void setStatisticManager(StatisticManager statisticManager) {
+            this.statisticManager = statisticManager;
+        }
+
         public Builder setBatchSize(int batchSize) {
             this.batchSize = batchSize;
             return this;
@@ -511,10 +575,10 @@ public class DomaConfig implements Config {
                     commenter,
                     entityListenerProvider,
                     transactionManager,
-                    batchSize,
-                    fetchSize,
-                    maxRows,
-                    queryTimeout);
+                    duplicateColumnHandler,
+                    sqlBuilderSettings,
+                    statisticManager,
+                    batchSize, fetchSize, maxRows, queryTimeout);
         }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaConfig.java
@@ -93,9 +93,9 @@ public class DomaConfig implements Config {
         this.commenter = Objects.requireNonNull(commenter);
         this.entityListenerProvider = Objects.requireNonNull(entityListenerProvider);
         this.transactionManager = Objects.requireNonNull(transactionManager);
-        this.duplicateColumnHandler = duplicateColumnHandler;
-        this.sqlBuilderSettings = sqlBuilderSettings;
-        this.statisticManager = statisticManager;
+        this.duplicateColumnHandler = Objects.requireNonNull(duplicateColumnHandler);
+        this.sqlBuilderSettings = Objects.requireNonNull(sqlBuilderSettings);
+        this.statisticManager = Objects.requireNonNull(statisticManager);
         this.batchSize = batchSize;
         this.fetchSize = fetchSize;
         this.maxRows = maxRows;

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaProducer.java
@@ -39,6 +39,8 @@ public class DomaProducer {
     private volatile Naming naming;
     private volatile SqlLogType exceptionSqlLogType;
     private volatile Map<String, String> namedSqlLoadScripts;
+    private volatile SqlBuilderSettings sqlBuilderSettings;
+    private volatile DuplicateColumnHandler duplicateColumnHandler;
 
     public void setSqlFileRepository(SqlFileRepository sqlFileRepository) {
         this.sqlFileRepository = Objects.requireNonNull(sqlFileRepository);
@@ -61,6 +63,14 @@ public class DomaProducer {
         this.namedSqlLoadScripts = Collections.unmodifiableMap(namedSqlLoadScripts);
     }
 
+    public void setSqlBuilderSettings(SqlBuilderSettings sqlBuilderSettings) {
+        this.sqlBuilderSettings = Objects.requireNonNull(sqlBuilderSettings);
+    }
+
+    public void setDuplicateColumnHandler(DuplicateColumnHandler duplicateColumnHandler) {
+        this.duplicateColumnHandler = duplicateColumnHandler;
+    }
+
     @Singleton
     @DefaultBean
     SqlFileRepository sqlFileRepository() {
@@ -71,6 +81,12 @@ public class DomaProducer {
     @DefaultBean
     ScriptFileLoader scriptFileLoader() {
         return Objects.requireNonNull(scriptFileLoader);
+    }
+
+    @Singleton
+    @DefaultBean
+    SqlBuilderSettings sqlBuilderSettings() {
+        return Objects.requireNonNull(sqlBuilderSettings);
     }
 
     @Singleton
@@ -123,14 +139,8 @@ public class DomaProducer {
 
     @Singleton
     @DefaultBean
-    DuplicateColumnHandler SqlBuilderSettings() {
-        return ConfigSupport.defaultDuplicateColumnHandler;
-    }
-
-    @Singleton
-    @DefaultBean
-    SqlBuilderSettings sqlBuilderSettings() {
-        return ConfigSupport.defaultSqlBuilderSettings;
+    DuplicateColumnHandler duplicateColumnHandler() {
+        return duplicateColumnHandler;
     }
 
     @Singleton

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaProducer.java
@@ -140,7 +140,7 @@ public class DomaProducer {
     @Singleton
     @DefaultBean
     DuplicateColumnHandler duplicateColumnHandler() {
-        return duplicateColumnHandler;
+        return Objects.requireNonNull(duplicateColumnHandler);
     }
 
     @Singleton

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaProducer.java
@@ -11,6 +11,7 @@ import org.seasar.doma.jdbc.ClassHelper;
 import org.seasar.doma.jdbc.CommandImplementors;
 import org.seasar.doma.jdbc.Commenter;
 import org.seasar.doma.jdbc.ConfigSupport;
+import org.seasar.doma.jdbc.DuplicateColumnHandler;
 import org.seasar.doma.jdbc.EntityListenerProvider;
 import org.seasar.doma.jdbc.JdbcLogger;
 import org.seasar.doma.jdbc.MapKeyNaming;
@@ -18,9 +19,11 @@ import org.seasar.doma.jdbc.Naming;
 import org.seasar.doma.jdbc.QueryImplementors;
 import org.seasar.doma.jdbc.RequiresNewController;
 import org.seasar.doma.jdbc.ScriptFileLoader;
+import org.seasar.doma.jdbc.SqlBuilderSettings;
 import org.seasar.doma.jdbc.SqlFileRepository;
 import org.seasar.doma.jdbc.SqlLogType;
 import org.seasar.doma.jdbc.UnknownColumnHandler;
+import org.seasar.doma.jdbc.statistic.StatisticManager;
 import org.seasar.doma.jdbc.tx.TransactionManager;
 import org.seasar.doma.slf4j.Slf4jJdbcLogger;
 
@@ -120,6 +123,24 @@ public class DomaProducer {
 
     @Singleton
     @DefaultBean
+    DuplicateColumnHandler SqlBuilderSettings() {
+        return ConfigSupport.defaultDuplicateColumnHandler;
+    }
+
+    @Singleton
+    @DefaultBean
+    SqlBuilderSettings sqlBuilderSettings() {
+        return ConfigSupport.defaultSqlBuilderSettings;
+    }
+
+    @Singleton
+    @DefaultBean
+    StatisticManager statisticManager() {
+        return ConfigSupport.defaultStatisticManager;
+    }
+
+    @Singleton
+    @DefaultBean
     EntityListenerProvider entityListenerProvider() {
         return ConfigSupport.defaultEntityListenerProvider;
     }
@@ -153,7 +174,10 @@ public class DomaProducer {
             MapKeyNaming mapKeyNaming,
             Commenter commenter,
             EntityListenerProvider entityListenerProvider,
-            TransactionManager transactionManager) {
+            TransactionManager transactionManager,
+            DuplicateColumnHandler duplicateColumnHandler,
+            SqlBuilderSettings sqlBuilderSettings,
+            StatisticManager statisticManager) {
         return new DomaConfig.Core(
                 sqlFileRepository,
                 scriptFileLoader,
@@ -168,6 +192,9 @@ public class DomaProducer {
                 mapKeyNaming,
                 commenter,
                 entityListenerProvider,
-                transactionManager);
+                transactionManager,
+                duplicateColumnHandler,
+                sqlBuilderSettings,
+                statisticManager);
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaRecorder.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.Default;
 
 import org.seasar.doma.jdbc.Config;
 import org.seasar.doma.jdbc.ConfigSupport;
+import org.seasar.doma.jdbc.ThrowingDuplicateColumnHandler;
 import org.seasar.doma.jdbc.criteria.Entityql;
 import org.seasar.doma.jdbc.criteria.NativeSql;
 import org.seasar.doma.jdbc.criteria.QueryDsl;
@@ -46,7 +47,15 @@ public class DomaRecorder {
                 producer.setSqlFileRepository(domaSettings.sqlFileRepository.create());
                 producer.setScriptFileLoader(ConfigSupport.defaultScriptFileLoader);
             }
+            producer.setSqlBuilderSettings(new DefaultSqlBuilderSettings(
+                    domaSettings.sqlBuilderSettings.shouldRemoveBlankLines,
+                    domaSettings.sqlBuilderSettings.shouldRequireInListPadding));
 
+            if (domaSettings.throwExceptionIfDuplicateColumn) {
+                producer.setDuplicateColumnHandler(new ThrowingDuplicateColumnHandler());
+            } else {
+                producer.setDuplicateColumnHandler(ConfigSupport.defaultDuplicateColumnHandler);
+            }
             producer.setNaming(domaSettings.naming.naming());
             producer.setExceptionSqlLogType(domaSettings.exceptionSqlLogType);
             producer.setNamedSqlLoadScripts(domaSettings.asNamedSqlLoadScripts());

--- a/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaSettings.java
+++ b/runtime/src/main/java/io/quarkiverse/doma/runtime/DomaSettings.java
@@ -28,11 +28,26 @@ public class DomaSettings {
     public NamingType naming;
     public SqlLogType exceptionSqlLogType;
     public List<DataSourceSettings> dataSources;
+    public SqlBuilderSettings sqlBuilderSettings;
+    public boolean throwExceptionIfDuplicateColumn;
 
     public Map<String, String> asNamedSqlLoadScripts() {
         return dataSources.stream()
                 .filter(it -> it.sqlLoadScript != null)
                 .collect(toMap(it -> it.name, it -> it.sqlLoadScript, (a, b) -> a, LinkedHashMap::new));
+    }
+
+    public static class SqlBuilderSettings {
+        public boolean shouldRemoveBlankLines;
+        public boolean shouldRequireInListPadding;
+
+        @Override
+        public String toString() {
+            return "SqlBuilderSettings{" +
+                    "shouldRemoveBlankLines=" + shouldRemoveBlankLines +
+                    ", shouldRequireInListPadding=" + shouldRequireInListPadding +
+                    '}';
+        }
     }
 
     public static class DataSourceSettings {
@@ -135,6 +150,10 @@ public class DomaSettings {
                 + exceptionSqlLogType
                 + ", dataSources="
                 + dataSources
+                + ", sqlBuilderSettings="
+                + sqlBuilderSettings
+                + ", throwExceptionIfDuplicateColumn="
+                + throwExceptionIfDuplicateColumn
                 + '}';
     }
 }


### PR DESCRIPTION
The following components added to Doma2 will be managed by CDI.

|Class|Default value|
|:--:|:--:|
|DuplicateColumnHandler|ConfigSupport.defaultDuplicateColumnHandler|
|SqlBuilderSettings|ConfigSupport.defaultSqlBuilderSettings|
|StatisticManager|ConfigSupport.defaultStatisticManager|

Add new configuration property:
|property|default|description|
|:--:|:--:|:--|
|quarkus.doma.throw-exception-if-duplicate-column|false|When set to true, ThrowingDuplicateColumnHandler will be registered in CDI.When set to false, ConfigSupport.defaultDuplicateColumnHandler will be used.|
|quarkus.doma.sql-builder-settings.should-require-in-list-padding|false||
|quarkus.doma.sql-builder-settings.should-remove-blank-lines|false|

If DuplicateColumnHandler or SqlBuilderSettings is registered in CDI, these properties will be ignored.